### PR TITLE
add missing 'name' getter in constructor example

### DIFF
--- a/Chapter02.md
+++ b/Chapter02.md
@@ -98,6 +98,10 @@ class Person {
     @city = city
   }
 
+  def name {
+    @name
+  }
+
   def age {
     @age
   }


### PR DESCRIPTION
second constructor example is missing explicit 'name' getter - yes?
